### PR TITLE
feat: Add support for ItemUpdateDataEvent collectionsV2 event

### DIFF
--- a/proto/dcl.proto
+++ b/proto/dcl.proto
@@ -84,6 +84,20 @@ message CollectionSetGlobalMinterEvents {
     repeated CollectionSetGlobalMinterEvent events = 1;
 }
 
+message ItemUpdateDataEvent {
+  string collection = 1;
+  string item = 2;
+  BigInt price = 3;
+  string beneficiary = 4;
+  string raw_metadata = 5;
+  uint64 timestamp = 6;
+  uint64 block_number = 7;
+}
+
+message ItemUpdateDataEvents {
+    repeated ItemUpdateDataEvent events = 1;
+}
+
 message SetItemMinterEvent {
   string item = 1;
   string collection = 2;
@@ -163,8 +177,7 @@ message Wearable {
   string description = 3;
   string collection = 4;
   string category = 5;
-  string rarity = 6;
-  repeated string body_shapes = 7;
+  repeated string body_shapes = 6;
 }
 
 message Emote {
@@ -174,8 +187,7 @@ message Emote {
   string collection = 4;
   string category = 5;
   bool loop = 6;
-  string rarity = 7;
-  repeated string body_shapes = 8;
+  repeated string body_shapes = 7;
 }
 
 enum WearableCategory {

--- a/schema.sql
+++ b/schema.sql
@@ -65,27 +65,30 @@ create TABLE items (
 );
 CREATE TABLE metadata (
     id text NOT NULL PRIMARY KEY,
+    item_id TEXT NOT NULL,
     item_type TEXT NOT NULL,
     wearable text,
-    emote text
+    emote text,
+    timestamp TEXT NOT NULL,
+    block_number TEXT NOT NULL
 );
 CREATE TABLE wearable (
     id text NOT NULL PRIMARY KEY,
+    metadata text NOT NULL,
     name text NOT NULL,
     description text NOT NULL,
     collection text NOT NULL,
     category text NOT NULL,
-    rarity text NOT NULL,
     body_shapes text []
 );
 CREATE TABLE emote (
     id text NOT NULL PRIMARY KEY,
+    metadata text NOT NULL,
     name text NOT NULL,
     description text NOT NULL,
     collection text NOT NULL,
     category text NOT NULL,
     loop boolean NOT NULL,
-    rarity text NOT NULL,
     body_shapes text []
 );
 CREATE TABLE orders (
@@ -137,6 +140,16 @@ CREATE TABLE collection_set_global_minter_events (
     minter TEXT NOT NULL,
     value BOOLEAN NOT NULL,
     search_is_store_minter BOOLEAN NOT NULL,
+    timestamp TEXT NOT NULL,
+    block_number TEXT NOT NULL
+);
+CREATE TABLE update_item_data_events (
+    id TEXT NOT NULL PRIMARY KEY,
+    collection_id TEXT NOT NULL,
+    item_id TEXT NOT NULL,
+    price TEXT NOT NULL,
+    beneficiary TEXT NOT NULL,
+    raw_metadata TEXT NOT NULL,
     timestamp TEXT NOT NULL,
     block_number TEXT NOT NULL
 );

--- a/src/abi/collectionV2.rs
+++ b/src/abi/collectionV2.rs
@@ -936,6 +936,7 @@ pub mod functions {
             }
         }
         pub fn call(&self, address: Vec<u8>) -> Option<Vec<u8>> {
+            substreams::log::info!("here1");
             use substreams_ethereum::pb::eth::rpc;
             let rpc_calls = rpc::RpcCalls {
                 calls: vec![rpc::RpcCall {
@@ -943,6 +944,7 @@ pub mod functions {
                     data: self.encode(),
                 }],
             };
+            substreams::log::info!("Call About to call");
             let responses = substreams_ethereum::rpc::eth_call(&rpc_calls).responses;
             let response = responses.get(0).expect("one response should have existed");
             if response.failed {

--- a/src/data/wearables_v1/moonshot_2020.rs
+++ b/src/data/wearables_v1/moonshot_2020.rs
@@ -155,6 +155,14 @@ pub fn moonshot_2020() -> Vec<Wearable> {
             body_shapes: vec![String::from("BaseMale"), String::from("BaseFemale")],
         },
         Wearable {
+            id: String::from("ms_pixelchain_upper_body"),
+            name: String::from("Pixelchain Soccer T-Shirt"),
+            description: String::from("Pixelchain Soccer T-Shirt - Moonshot Tournament 2020"),
+            category: String::from("upper_body"),
+            rarity: String::from("legendary"),
+            body_shapes: vec![String::from("BaseMale"), String::from("BaseFemale")],
+        },
+        Wearable {
             id: String::from("ms_pm_upper_body"),
             name: String::from("Polygonal Mind Soccer T-Shirt"),
             description: String::from("Polygonal Mind Soccer T-Shirt - Moonshot Tournament 2020"),

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -104,28 +104,3 @@ pub fn get_token_uri(collection_address: Vec<u8>, token_id: BigInt) -> Option<St
     let func = abi::erc721::functions::TokenUri { token_id };
     func.call(collection_address)
 }
-
-// pub fn get_collection_v1_item_count(collection_address: Vec<u8>) -> Option<BigInt> {
-//     let func = abi::erc721::functions::ItemsCount {};
-//     func.call(collection_address)
-// }
-
-// type CollectionItemTuple = (
-//     std::string::String,
-//     substreams::scalar::BigInt,
-//     substreams::scalar::BigInt,
-//     substreams::scalar::BigInt,
-//     Vec<u8>,
-//     std::string::String,
-//     std::string::String,
-// );
-
-// pub fn get_collection_item(
-//     collection_address: Vec<u8>,
-//     item_id: u64,
-// ) -> Option<CollectionItemTuple> {
-//     let items = abi::collections_v2::functions::Items {
-//         param0: BigInt::from(item_id),
-//     };
-//     items.call(collection_address)
-// }

--- a/src/utils/items.rs
+++ b/src/utils/items.rs
@@ -1,6 +1,6 @@
 use substreams::log;
 
-use crate::pb::dcl::{Item, Metadata};
+use crate::pb::dcl::Metadata;
 
 use super::metadata::{build_emote_item, build_wearable_item};
 
@@ -33,8 +33,8 @@ pub fn get_item_type_from_metadata(raw_metadata: String) -> ItemMetadata {
     }
 }
 
-pub fn build_metadata(item: &Item) -> Metadata {
-    let id = item.id.clone();
+pub fn build_metadata(item_id: &str, raw_metadata: &str, collection: &str) -> Metadata {
+    let id = item_id.to_string();
     let mut metadata = Metadata {
         id,
         item_type: "".to_string(),
@@ -42,12 +42,12 @@ pub fn build_metadata(item: &Item) -> Metadata {
         emote: None,
     };
 
-    let data: Vec<&str> = item.raw_metadata.split(':').collect();
+    let data: Vec<&str> = raw_metadata.split(':').collect();
     if data.len() >= 2 {
         let item_type = data[1];
 
         if item_type == WEARABLE_TYPE_SHORT {
-            let wearable = build_wearable_item(item);
+            let wearable = build_wearable_item(item_id, raw_metadata, collection);
             if let Some(wearable) = wearable {
                 metadata.item_type = WEARABLE_V2.to_string();
                 metadata.wearable = Some(wearable);
@@ -55,7 +55,7 @@ pub fn build_metadata(item: &Item) -> Metadata {
                 metadata.item_type = "".to_string();
             }
         } else if item_type == SMART_WEARABLE_TYPE_SHORT {
-            let wearable = build_wearable_item(item);
+            let wearable = build_wearable_item(item_id, raw_metadata, collection);
             if let Some(wearable) = wearable {
                 metadata.item_type = SMART_WEARABLE_V1.to_string();
                 metadata.wearable = Some(wearable);
@@ -63,7 +63,7 @@ pub fn build_metadata(item: &Item) -> Metadata {
                 metadata.item_type = "".to_string();
             }
         } else if item_type == EMOTE_TYPE_SHORT {
-            let emote = build_emote_item(item);
+            let emote = build_emote_item(item_id, raw_metadata, collection);
             if let Some(emote) = emote {
                 metadata.item_type = EMOTE_V1.to_string();
                 metadata.emote = Some(emote);

--- a/src/utils/metadata.rs
+++ b/src/utils/metadata.rs
@@ -1,20 +1,23 @@
-use crate::pb::dcl::{Emote, Item, Wearable};
+use crate::pb::dcl::{Emote, Wearable};
 
-pub fn build_wearable_item(item: &Item) -> Option<Wearable> {
-    let id = item.id.clone();
-    let data: Vec<&str> = item.raw_metadata.split(':').collect();
+pub fn build_wearable_item(
+    item_id: &str,
+    raw_metadata: &str,
+    collection: &str,
+) -> Option<Wearable> {
+    let id = item_id.to_string();
+    let data: Vec<&str> = raw_metadata.split(':').collect();
 
     if (data.len() == 6 || data.len() == 8)
         && is_valid_wearable_category(data[4])
         && is_valid_body_shape(&data[5].split(',').collect::<Vec<&str>>()[..])
     {
         let wearable = Wearable {
-            id: id.clone(),
+            id,
             name: data[2].to_string(),
             description: data[3].to_string(),
-            collection: item.collection.clone(),
+            collection: collection.to_string(),
             category: data[4].to_string(),
-            rarity: item.rarity.to_string(),
             body_shapes: data[5]
                 .split(',')
                 .map(|s| s.to_string())
@@ -51,19 +54,18 @@ fn is_valid_body_shape(body_shapes: &[&str]) -> bool {
 
 // Emotes
 
-pub fn build_emote_item(item: &Item) -> Option<Emote> {
-    let id = item.id.clone();
-    let data: Vec<&str> = item.raw_metadata.split(':').collect();
+pub fn build_emote_item(item_id: &str, raw_metadata: &str, collection: &str) -> Option<Emote> {
+    let id = item_id.to_string();
+    let data: Vec<&str> = raw_metadata.split(':').collect();
     let data_has_valid_length = data.len() == 6 || data.len() == 7 || data.len() == 8;
 
     if data_has_valid_length && is_valid_body_shape(&data[5].split(',').collect::<Vec<&str>>()[..])
     {
         let emote = Emote {
-            id: id.clone(),
-            collection: item.collection.clone(),
+            id,
+            collection: collection.to_string(),
             name: data[2].to_string(),
             description: data[3].to_string(),
-            rarity: item.rarity.to_string(),
             category: if is_valid_emote_category(data[4]) {
                 data[4].to_string()
             } else {

--- a/src/utils/urn.rs
+++ b/src/utils/urn.rs
@@ -1,6 +1,6 @@
 const BASE_DECENTRALAND_URN: &str = "urn:decentraland:";
 
-pub fn get_urn_for_collection_v2(collection_address: &str, network: String) -> String {
+pub fn get_urn_for_collection_v2(collection_address: &str, network: &str) -> String {
     format!(
         "{}{}:collections-v2:{}",
         BASE_DECENTRALAND_URN, network, collection_address

--- a/substreams-goerli.yaml
+++ b/substreams-goerli.yaml
@@ -38,6 +38,7 @@ modules:
     kind: map
     initialBlock: 7103733
     inputs:
+      - params: string
       - map: map_add_items_v1
       - store: store_collections_v1
     output:
@@ -106,6 +107,7 @@ modules:
 
 params:
   db_out: "goerli"
+  map_add_collections_v1: "goerli"
   map_add_items_v1: "goerli"
   map_order_created: "goerli"
   map_order_executed: "goerli"

--- a/substreams-mainnet.yaml
+++ b/substreams-mainnet.yaml
@@ -38,6 +38,7 @@ modules:
     kind: map
     initialBlock: 8828687
     inputs:
+      - params: string
       - map: map_add_items_v1
       - store: store_collections_v1
     output:
@@ -106,6 +107,7 @@ modules:
 
 params:
   db_out: "mainnet"
+  map_add_collections_v1: "mainnet"
   map_add_items_v1: "mainnet"
   map_order_created: "mainnet"
   map_order_executed: "mainnet"

--- a/substreams-mumbai.yaml
+++ b/substreams-mumbai.yaml
@@ -43,6 +43,15 @@ modules:
     output:
       type: proto:dcl.CollectionSetApprovedEvents
 
+  - name: map_item_update_data_event
+    kind: map
+    initialBlock: 14517370
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_collections
+    output:
+      type: proto:dcl.ItemUpdateDataEvents
+
   - name: map_collection_set_global_minter_event
     kind: map
     initialBlock: 14517370
@@ -82,6 +91,7 @@ modules:
     kind: map
     initialBlock: 14517370
     inputs:
+      - params: string
       - source: sf.ethereum.type.v2.Block
       - map: map_collection_created # depends on the map and not store because the AddItem happens in the same block as the ProxyCreated event, so the store won't have the address yet
     output:
@@ -125,6 +135,7 @@ modules:
       - map: map_collection_set_approved_event
       - map: map_collection_set_global_minter_event
       - map: map_collection_set_item_minter_event
+      - map: map_item_update_data_event
       - map: map_order_created
       - map: map_order_executed
       - map: map_order_cancelled
@@ -133,6 +144,7 @@ modules:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
 params:
+  map_add_items: "mumbai"
   map_collection_created: "mumbai"
   map_order_created: "mumbai"
   map_order_executed: "mumbai"

--- a/substreams-polygon.yaml
+++ b/substreams-polygon.yaml
@@ -42,6 +42,15 @@ modules:
       - store: store_collections
     output:
       type: proto:dcl.CollectionSetApprovedEvents
+  
+  - name: map_item_update_data_event
+    kind: map
+    initialBlock: 15202000
+    inputs:
+      - source: sf.ethereum.type.v2.Block
+      - store: store_collections
+    output:
+      type: proto:dcl.ItemUpdateDataEvents
 
   - name: map_collection_set_global_minter_event
     kind: map
@@ -82,6 +91,7 @@ modules:
     kind: map
     initialBlock: 15202000
     inputs:
+      - params: string
       - source: sf.ethereum.type.v2.Block
       - map: map_collection_created # depends on the map and not store because the AddItem happens in the same block as the ProxyCreated event, so the store won't have the address yet
     output:
@@ -125,6 +135,7 @@ modules:
       - map: map_collection_set_approved_event
       - map: map_collection_set_global_minter_event
       - map: map_collection_set_item_minter_event
+      - map: map_item_update_data_event
       - map: map_order_created
       - map: map_order_executed
       - map: map_order_cancelled
@@ -133,6 +144,7 @@ modules:
       type: proto:sf.substreams.sink.database.v1.DatabaseChanges
 
 params:
+  map_add_items: "polygon"
   map_collection_created: "polygon"
   map_order_created: "polygon"
   map_order_executed: "polygon"


### PR DESCRIPTION
This PR includes:
- Reads the `ItemUpdateDataEvent` and stores in the `update_item_data_events`
- Unharcodes the `polygon` and `mumbai` arrays and use `params` for the network
- saves a new metadata event for each ItemUpdateDataEvent and so the metadata key now will be composed of the metadata id and timestamp to avoid conflicts.