### PR TITLE
fix: emotes category metadata and metadata id for update events

### DIFF
--- a/src/db/items.rs
+++ b/src/db/items.rs
@@ -135,8 +135,7 @@ pub fn update_item_data(changes: &mut Tables, events: dcl::ItemUpdateDataEvents)
             .set("timestamp", event.timestamp)
             .set("block_number", event.block_number);
 
-        let metadata =
-            utils::items::build_metadata(&event.item, &event.raw_metadata, &event.collection);
+        let metadata = utils::items::build_metadata(&item, &event.raw_metadata, &event.collection);
         update_metadata(changes, metadata, event.timestamp, event.block_number);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -572,7 +572,11 @@ pub fn map_add_items(
                     content_hash,
                 } = item;
                 sanitize_sql_string(metadata.clone());
-                let item_urn = utils::urn::get_urn_for_collection_v2(&collection_address, &network);
+                let item_urn = utils::urn::get_urn_for_collection_v2(
+                    &collection_address,
+                    &add_item_event.item_id.to_string(),
+                    &network,
+                );
                 let item_id = utils::get_item_id(
                     Hex(log.address()).to_string(),
                     add_item_event.item_id.to_string(),

--- a/src/utils/items.rs
+++ b/src/utils/items.rs
@@ -86,7 +86,7 @@ fn get_catalyst_base() -> String {
         return "https://peer.decentraland.org".to_string();
     }
 
-    if network == "ropsten" || network == "goerli" || network == "mumbai" {
+    if network == "ropsten" || network == "goerli" || network == "mumbai" || network == "sepolia" {
         return "https://peer.decentraland.zone".to_string();
     }
 

--- a/src/utils/metadata.rs
+++ b/src/utils/metadata.rs
@@ -69,7 +69,7 @@ pub fn build_emote_item(item_id: &str, raw_metadata: &str, collection: &str) -> 
             category: if is_valid_emote_category(data[4]) {
                 data[4].to_string()
             } else {
-                "DANCE".to_string() // Fallback to "DANCE" for old emotes
+                "dance".to_string() // Fallback to "dance" for old emotes
             },
             body_shapes: data[5]
                 .split(',')
@@ -86,8 +86,8 @@ pub fn build_emote_item(item_id: &str, raw_metadata: &str, collection: &str) -> 
 
 fn is_valid_emote_category(category: &str) -> bool {
     match category {
-        "DANCE" | "STUNT" | "GREETINGS" | "FUN" | "POSES" | "REACTIONS" | "HORROR"
-        | "MISCELLANEOUS" => true,
+        "dance" | "stunt" | "greetings" | "fun" | "poses" | "reactions" | "horror"
+        | "miscellaneous" => true,
         _ => {
             substreams::log::info!("Invalid Category {}", category);
             false

--- a/src/utils/urn.rs
+++ b/src/utils/urn.rs
@@ -1,9 +1,14 @@
 const BASE_DECENTRALAND_URN: &str = "urn:decentraland:";
 
-pub fn get_urn_for_collection_v2(collection_address: &str, network: &str) -> String {
+pub fn get_urn_for_collection_v2(collection_address: &str, item_id: &str, network: &str) -> String {
+    let formatted_network = if network == "polygon" {
+        "matic"
+    } else {
+        network
+    };
     format!(
-        "{}{}:collections-v2:{}",
-        BASE_DECENTRALAND_URN, network, collection_address
+        "{}{}:collections-v2:{}:{}",
+        BASE_DECENTRALAND_URN, network, collection_address, item_id
     )
 }
 


### PR DESCRIPTION
This PR fixes 
- the emote categories
- the metadata `id` stored in the db for the item data updates
- how the URNs are crafted