### PR TITLE
fix: add missing idx on collection_set_approved_events_view

### DIFF
--- a/triggers.sql
+++ b/triggers.sql
@@ -206,6 +206,8 @@ FROM
 WHERE
     row_num = 1;
 
+CREATE UNIQUE INDEX idx_collection_set_approved_events_view_collection_id 
+ON collection_set_approved_events_view(collection_id);
 ----- item_sold_at_view
 
 CREATE MATERIALIZED VIEW item_sold_at_view AS


### PR DESCRIPTION
This is the error that the command to refresh the view throws without this index
```
refreshing materialized view dcl36.collection_set_approved_events_view: error: cannot refresh materialized view "dcl36.collection_set_approved_events_view" concurrently
    at /home/admin/decentraland-substreams/scripts/node_modules/pg/lib/client.js:526:17
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  length: 246,
  severity: 'ERROR',
  code: '55000',
  detail: undefined,
  hint: 'Create a unique index with no WHERE clause on one or more columns of the materialized view.',
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'matview.c',
  line: '254',
  routine: 'ExecRefreshMatView'
}
```